### PR TITLE
More content crud

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,12 +18,6 @@
  *= require_self
  */
 
-
- body{
-    /*background-color: #BED7C1;  in scheme trying different */
-    background-color: #6FB893;
- }
-
 .thumbnail-pic{
   width: 320px;
   height: 150px;
@@ -33,10 +27,6 @@
 .cat-button {
   background-color: #F4EDD6;
 }
-
-.cat-button:hover {
-  background-color: red;
-  }
 
 .caption {
     background-color: #F4EDD6;

--- a/app/assets/stylesheets/overrides.css
+++ b/app/assets/stylesheets/overrides.css
@@ -1,3 +1,25 @@
+/********************
+* Site Wide         *
+********************/
+
+/**************************
+* Palette:
+***************************
+*  Cream: 					#F4EDD6
+*  Red: 						#E2493C
+*  Dark teal: 			#6FB893
+*  Light teal: 			#BED7C1
+*  Greenish slate:  #C6CAAF
+*  Dark mustard:    #B69155
+**************************/
+
+
+ body{
+    /*background-color: #BED7C1;  in scheme trying different */
+    background-color: #6FB893;
+ }
+
+
 #cart {
 	color: #6FB893;
 	margin-top: 13px;
@@ -34,3 +56,34 @@
 	color:  #BED7C1;
 	text-decoration: none;
 }
+
+/*************************
+* Content Form           *
+*************************/
+
+#form-pane{
+	margin-top: 40px;
+	margin-left: 40px;
+}
+.header-well{
+	margin: auto;
+	width: 85%;
+	}
+
+.spacer{
+	height: 20px;
+}
+
+.inner-form{
+	width: 85%;
+	margin: auto;
+}
+
+.question-box{
+	border: 3px solid #BED7C1;
+	background-color: #F4EDD6;
+	border-radius: 4px;
+	}
+
+
+

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -3,7 +3,7 @@ class ContentController < ApplicationController
     @content = Content.new
   end
 
-  def submit
+  def create
     @content = Content.new(content_params)
     if @content.save
       redirect_to content_path
@@ -18,7 +18,15 @@ class ContentController < ApplicationController
 
   def edit
     @content = Content.find(params[:id])
-    byebug
+  end
+
+  def update
+    @content = Content.find(params[:id])
+    if @content.update(content_params)
+      redirect_to content_path
+    else
+      redirect_to edit_content_path
+    end
   end
 
   private

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -29,6 +29,12 @@ class ContentController < ApplicationController
     end
   end
 
+  def destroy
+    @content = Content.find(params[:id])
+    @content.delete
+    redirect_to content_path
+  end
+
   private
   def content_params
     params.require(:content).permit(:name, :payload)

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -1,21 +1,21 @@
 
 <div class="container row well col-sm-6" id="form-pane">
   <div class="container row well header-well">
-    <h1>New Content</h1>
+    <h1>Edit Content</h1>
   </div>
 
   <div class="container spacer">
   </div>
 
   <div class="container col-sm-6 row well inner-form">
-  <%= form_for(@content, url: content_submit_path) do |f| %>
+  <%= form_for(@content, url: content_submit_path(id: @content.id)) do |f| %>
     <%= f.label :name, 'Unique name:' %><br>
     <%= f.text_field :name, {class: 'question-box'} %><br>
 
     <%= f.label :payload, "Payload:" %><br>
     <%= f.text_area :payload, {class: 'question-box'} %><br>
 
-    <%= f.submit 'Create content' %>
+    <%= f.submit 'Save content' %>
   <% end %>
   </div>
 </div>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -17,6 +17,9 @@
       </td>
       <td>
         <%= link_to("Edit", edit_content_path(c), class: "btn btn-primary") %>
+        <%= link_to delete_content_path(c), method: :delete, class: "btn btn-danger" do %>
+          Delete
+        <% end %>
       </td>
       <td><%= c.payload %></td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   patch '/content/submit', to: 'content#update'
   get '/content', to: 'content#index'
   get '/content/:id/edit', to: 'content#edit', as: 'edit_content'
-  delete '/content/:id', to: 'content#destroy'
+  delete '/content/:id', to: 'content#destroy', as: 'delete_content'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
 
   #content routes - manually done b/c no singular/plural distinction
   get '/content/new', to: 'content#new'
-  post '/content/submit', to: 'content#submit'
+  post '/content/submit', to: 'content#create'
+  patch '/content/submit', to: 'content#update'
   get '/content', to: 'content#index'
   get '/content/:id/edit', to: 'content#edit', as: 'edit_content'
   delete '/content/:id', to: 'content#destroy'

--- a/spec/features/content_crud_flow_spec.rb
+++ b/spec/features/content_crud_flow_spec.rb
@@ -12,7 +12,7 @@ feature 'content can be added' do
       OpenStruct.new(name: "Paragraph",
         payload: "Different. 23489s;lkas")
     } 
-    xit 'creates a content record' do
+    it 'creates a content record' do
       visit '/content/new'
       expect(current_path).to eq('/content/new')
       fill_in 'Unique name', with: attributes_1.name
@@ -23,7 +23,7 @@ feature 'content can be added' do
       expect(page).to have_content(attributes_1.name)
     end
 
-    xit 'can view all content records' do
+    it 'can view all content records' do
       visit '/content'
       expect(current_path).to eq('/content')
       expect(page).to have_content("Butter")
@@ -32,16 +32,21 @@ feature 'content can be added' do
       expect(page).to have_content("Maecenas tincidunt")
     end
 
-    xit 'has links to edit content' do
+    it 'has links to edit content' do
       visit '/content'
       Content.all.each do |c|
-        expect(page).to have_button("Edit", edit_content_path(c))
+        expect(page).to have_link("Edit", edit_content_path(c))
       end
     end
 
-    xit 'can edit content' do
+    it 'can edit content' do
       visit '/content'
-      first(:button, "Edit").click
+      first(:link, "Edit").click
+      expect(current_path).to eq('/content/1/edit')
+      fill_in :name, with: attributes_2.name
+      fill_in 'Payload', with: attributes_2.payload
+      click_button 'Save content'
+
     end
   end
 end

--- a/spec/features/content_crud_flow_spec.rb
+++ b/spec/features/content_crud_flow_spec.rb
@@ -40,13 +40,33 @@ feature 'content can be added' do
     end
 
     it 'can edit content' do
+      first_content = Content.all.first
       visit '/content'
+      expect(page).to have_content(first_content.name)
       first(:link, "Edit").click
       expect(current_path).to eq('/content/1/edit')
       fill_in :name, with: attributes_2.name
       fill_in 'Payload', with: attributes_2.payload
       click_button 'Save content'
+      expect(page).to have_content(attributes_2.name)
+      expect(page).to have_content(attributes_2.payload)
+      expect(page).to_not have_content(first_content.name)
+    end
 
+    it 'has links to delete content' do
+      visit '/content'
+      Content.all.each do |c|
+        expect(page).to have_link('Delete', delete_content_path(c))
+      end
+    end
+
+    it 'can delete content' do
+      visit '/content'
+      first_content = Content.all.first
+      expect(page).to have_content(first_content.name)
+      first(:link, "Delete").click
+      expect(current_path).to eq(content_path)
+      expect(page).to_not have_content(first_content.name)
     end
   end
 end


### PR DESCRIPTION
Stylized the content creation form somewhat, completed most crud functionality (not creating show right now). Index, edit, and delete are good.

This form/view is going to be used to create and store the copy for the about page and the home page (testimonials). That way all copy will be editable by the client. Things like randomization could be used to keep the views fresh. It will also aid in the development of these pages presently.

Oh, also, I added our palette as comments to the css page, and moved styling out of the applications css file. 