### PR TITLE
Admin orders testing

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -5,7 +5,12 @@ class Admin::OrdersController < AdminController
   end
 
   def by_status
-    @orders = Order.by_status(params[:status])
+    status = params[:status].capitalize
+    if Order.legal_status.include?(status)
+      @orders = Order.by_status(status)
+    else
+      render_404("Bad status code")
+    end
   end
 
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,4 +40,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def render_404(msg = "Page not found")
+    flash[:error] = msg
+    redirect_to error_path status: 404
+    # raise ActionController::RoutingError.new('
+  end
+
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,9 @@ class CategoriesController < ApplicationController
 
   def show
     @category = Category.find_by(slug: params[:slug])
-    # need action for non-existent category
+    if !@category
+      render_404("Category not found")
+    end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,5 +49,6 @@ class ItemsController < ApplicationController
 
     def load_item
       @item = Item.find_by(slug: params[:slug])
+      render_404("Item not found") if !@item
     end
 end

--- a/spec/features/admin_orders_spec.rb
+++ b/spec/features/admin_orders_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+feature 'admin order viewing' do
+  before do
+    login_user!
+    10.times do
+      create_order
+    end
+    login_admin!
+  end
+
+  it 'sees correct number of ordered items' do
+    visit "/admin/orders"
+    expect(page).to have_link("10", "/admin/orders/by_status/ordered")
+  end
+
+  it 'status counts change with status change button clicking' do
+    visit "/admin/orders"
+    expect(page).to have_link("Mark as Paid")
+    3.times { first(:link, "Mark as Paid").click }
+    expect(page).to have_link("7", "/admin/orders/by_status/ordered")
+    expect(page).to have_link("3", "/admin/orders/by_status/paid")
+    3.times { first(:link, "Cancel").click }
+    expect(page).to have_link("3", "/admin/orders/by_status/cancelled")
+    2.times { first(:link, "Mark as Completed").click }
+    expect(page).to have_link("2", "/admin/orders/by_status/paid")
+  end
+
+end


### PR DESCRIPTION
Strengthen admin orders tests, add some guardrails for passing bad items/categories/statuses. Added render_404 method to accommodate this.